### PR TITLE
Sync changes to support more k8s node resources in template

### DIFF
--- a/apps/caprox-engine.yaml
+++ b/apps/caprox-engine.yaml
@@ -11,8 +11,8 @@ spec:
     server: https://kubernetes.default.svc
   project: default
   source:
-    repoURL: https://github.com/Caprox-eu/Proxmox-Kubernetes-Engine.git
-    targetRevision: 99c87250802d886cfce28fe20a313637eae8a80a
+    repoURL: https://github.com/recontech404/Proxmox-Kubernetes-Engine.git
+    targetRevision: 912ff3fe949990711808e06e770d5ad95ac94bd2
     path: manifests/clusterclass-cilium-with-shared-ippool/base
   syncPolicy:
     syncOptions:

--- a/manifests/clusterclass-cilium-with-shared-ippool/base/kustomization.yaml
+++ b/manifests/clusterclass-cilium-with-shared-ippool/base/kustomization.yaml
@@ -78,3 +78,12 @@ patches:
   - path: patches/ProxmoxMachineTemplate/WorkerNodeSockets.yaml
     target:
       kind: ClusterClass
+  - path: patches/ProxmoxMachineTemplate/ControlPlaneBootDisk.yaml
+    target:
+      kind: ClusterClass
+  - path: patches/ProxmoxMachineTemplate/ControlPlaneCores.yaml
+    target:
+      kind: ClusterClass
+  - path: patches/ProxmoxMachineTemplate/WorkerNodeBootDisk.yaml
+    target:
+      kind: ClusterClass

--- a/manifests/clusterclass-cilium-with-shared-ippool/base/patches/ProxmoxMachineTemplate/ControlPlaneBootDisk.yaml
+++ b/manifests/clusterclass-cilium-with-shared-ippool/base/patches/ProxmoxMachineTemplate/ControlPlaneBootDisk.yaml
@@ -1,0 +1,21 @@
+- op: add
+  path: /spec/patches/-
+  value:
+    name: ControlPlaneBootDisk
+    description: "Configure Control Plane boot disk device & size"
+    enabledIf: "{{ if .cloneSpec.machineSpec.controlPlane.disks.bootVolume.sizeGb }}true{{ end }}"
+    definitions:
+      - selector:
+          apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
+          kind: ProxmoxMachineTemplate
+          matchResources:
+            controlPlane: true
+        jsonPatches:
+          - op: add
+            path: /spec/template/spec/disks/bootVolume/disk
+            valueFrom:
+              variable: cloneSpec.machineSpec.controlPlane.disks.bootVolume.disk
+          - op: add
+            path: /spec/template/spec/disks/bootVolume/sizeGb
+            valueFrom:
+              variable: cloneSpec.machineSpec.controlPlane.disks.bootVolume.sizeGb

--- a/manifests/clusterclass-cilium-with-shared-ippool/base/patches/ProxmoxMachineTemplate/ControlPlaneBootDisk.yaml
+++ b/manifests/clusterclass-cilium-with-shared-ippool/base/patches/ProxmoxMachineTemplate/ControlPlaneBootDisk.yaml
@@ -12,6 +12,12 @@
             controlPlane: true
         jsonPatches:
           - op: add
+            path: /spec/template/spec/disks
+            value: {}
+          - op: add
+            path: /spec/template/spec/disks/bootVolume
+            value: {}
+          - op: add
             path: /spec/template/spec/disks/bootVolume/disk
             valueFrom:
               variable: cloneSpec.machineSpec.controlPlane.disks.bootVolume.disk

--- a/manifests/clusterclass-cilium-with-shared-ippool/base/patches/ProxmoxMachineTemplate/ControlPlaneCloneDiskFormat.yaml
+++ b/manifests/clusterclass-cilium-with-shared-ippool/base/patches/ProxmoxMachineTemplate/ControlPlaneCloneDiskFormat.yaml
@@ -3,7 +3,7 @@
   value:
     name: ControlPlaneCloneDiskFormat
     description: "Configure ControlPlane Qemu Disk Format"
-    enabledIf: "{{ if .cloneSpec.machineSpec.workerNode.format }}true{{ end }}"
+    enabledIf: "{{ if .cloneSpec.machineSpec.controlPlane.format }}true{{ end }}"
     definitions:
       - selector:
           apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1

--- a/manifests/clusterclass-cilium-with-shared-ippool/base/patches/ProxmoxMachineTemplate/ControlPlaneCores.yaml
+++ b/manifests/clusterclass-cilium-with-shared-ippool/base/patches/ProxmoxMachineTemplate/ControlPlaneCores.yaml
@@ -1,9 +1,9 @@
 - op: add
   path: /spec/patches/-
   value:
-    name: ControlPlaneNodeSockets
-    description: "Configure Control Plane Sockets"
-    enabledIf: "{{ if .cloneSpec.machineSpec.controlPlane.numSockets }}true{{ end }}"
+    name: ControlPlaneCores
+    description: "Configure Control Plane Cores"
+    enabledIf: "{{ if .cloneSpec.machineSpec.controlPlane.numCores }}true{{ end }}"
     definitions:
       - selector:
           apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
@@ -12,6 +12,6 @@
             controlPlane: true
         jsonPatches:
           - op: add
-            path: /spec/template/spec/numSockets
+            path: /spec/template/spec/numCores
             valueFrom:
-              variable: cloneSpec.machineSpec.controlPlane.numSockets
+              variable: cloneSpec.machineSpec.controlPlane.numCores

--- a/manifests/clusterclass-cilium-with-shared-ippool/base/patches/ProxmoxMachineTemplate/ControlPlaneMem.yaml
+++ b/manifests/clusterclass-cilium-with-shared-ippool/base/patches/ProxmoxMachineTemplate/ControlPlaneMem.yaml
@@ -3,7 +3,7 @@
   value:
     name: ControlPlaneMem
     description: "Configure ControlPlane Memory"
-    enabledIf: "{{ if .cloneSpec.machineSpec.workerNode.memoryMiB }}true{{ end }}"
+    enabledIf: "{{ if .cloneSpec.machineSpec.controlPlane.memoryMiB }}true{{ end }}"
     definitions:
       - selector:
           apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1

--- a/manifests/clusterclass-cilium-with-shared-ippool/base/patches/ProxmoxMachineTemplate/WorkerNodeBootDisk.yaml
+++ b/manifests/clusterclass-cilium-with-shared-ippool/base/patches/ProxmoxMachineTemplate/WorkerNodeBootDisk.yaml
@@ -6,14 +6,20 @@
     enabledIf: "{{ if .cloneSpec.machineSpec.workerNode.disks.bootVolume.sizeGb }}true{{ end }}"
     definitions:
       - selector:
-          apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1  
+          apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
           kind: ProxmoxMachineTemplate
           matchResources:
             controlPlane: false
             machineDeploymentClass:
               names:
-                - proxmox-worker
+              - proxmox-worker
         jsonPatches:
+          - op: add
+            path: /spec/template/spec/disks
+            value: {}
+          - op: add
+            path: /spec/template/spec/disks/bootVolume
+            value: {}
           - op: add
             path: /spec/template/spec/disks/bootVolume/disk
             valueFrom:

--- a/manifests/clusterclass-cilium-with-shared-ippool/base/patches/ProxmoxMachineTemplate/WorkerNodeBootDisk.yaml
+++ b/manifests/clusterclass-cilium-with-shared-ippool/base/patches/ProxmoxMachineTemplate/WorkerNodeBootDisk.yaml
@@ -1,0 +1,24 @@
+- op: add
+  path: /spec/patches/-
+  value:
+    name: WorkerNodeBootDisk
+    description: "Configure WorkerNode boot disk device & size"
+    enabledIf: "{{ if .cloneSpec.machineSpec.workerNode.disks.bootVolume.sizeGb }}true{{ end }}"
+    definitions:
+      - selector:
+          apiVersion: infrastructure.cluster.x-k8s.io/v1beta1  
+          kind: ProxmoxMachineTemplate
+          matchResources:
+            controlPlane: false
+            machineDeploymentClass:
+              names:
+                - proxmox-worker
+        jsonPatches:
+          - op: add
+            path: /spec/template/spec/disks/bootVolume/disk
+            valueFrom:
+              variable: cloneSpec.machineSpec.workerNode.disks.bootVolume.disk
+          - op: add
+            path: /spec/template/spec/disks/bootVolume/sizeGb
+            valueFrom:
+              variable: cloneSpec.machineSpec.workerNode.disks.bootVolume.sizeGb

--- a/manifests/clusterclass-cilium-with-shared-ippool/base/patches/ProxmoxMachineTemplate/WorkerNodeBootDisk.yaml
+++ b/manifests/clusterclass-cilium-with-shared-ippool/base/patches/ProxmoxMachineTemplate/WorkerNodeBootDisk.yaml
@@ -6,7 +6,7 @@
     enabledIf: "{{ if .cloneSpec.machineSpec.workerNode.disks.bootVolume.sizeGb }}true{{ end }}"
     definitions:
       - selector:
-          apiVersion: infrastructure.cluster.x-k8s.io/v1beta1  
+          apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1  
           kind: ProxmoxMachineTemplate
           matchResources:
             controlPlane: false

--- a/manifests/clusterclass-cilium-with-shared-ippool/base/patches/ProxmoxMachineTemplate/WorkerNodeSockets.yaml
+++ b/manifests/clusterclass-cilium-with-shared-ippool/base/patches/ProxmoxMachineTemplate/WorkerNodeSockets.yaml
@@ -3,7 +3,7 @@
   value:
     name: WorkerNodeSockets
     description: "Configure Worker Node Sockets"
-    enabledIf: "{{ if .cloneSpec.machineSpecs.workerNode.numSockets }}true{{ end }}"
+    enabledIf: "{{ if .cloneSpec.machineSpec.workerNode.numSockets }}true{{ end }}"
     definitions:
       - selector:
           apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1

--- a/manifests/clusterclass-cilium-with-shared-ippool/base/variables/clonespec.yaml
+++ b/manifests/clusterclass-cilium-with-shared-ippool/base/variables/clonespec.yaml
@@ -45,13 +45,13 @@
                         properties:
                           disk:
                             type: string
-                      sizeGb:
-                        type: integer
-                        minimum: 5
-                        format: int32
-                    required:
-                    - disk
-                    - sizeGb
+                          sizeGb:
+                            type: integer
+                            minimum: 5
+                            format: int32
+                        required:
+                        - disk
+                        - sizeGb
                   format:
                     type: string
                     enum: [raw, qcow2, vmdk]

--- a/readme.md
+++ b/readme.md
@@ -333,8 +333,8 @@ spec:
     server: https://kubernetes.default.svc
   project: default
   source:
-    repoURL: https://github.com/Caprox-eu/Proxmox-Kubernetes-Engine.git
-    targetRevision: 99c87250802d886cfce28fe20a313637eae8a80a
+    repoURL: https://github.com/recontech404/Proxmox-Kubernetes-Engine.git
+    targetRevision: 912ff3fe949990711808e06e770d5ad95ac94bd2
     path: manifests/clusterclass-cilium-with-shared-ippool/base
   syncPolicy:
     syncOptions:
@@ -474,6 +474,21 @@ spec:
         vmTemplate:
           sourceNode: node01
           templateID: 114
+        
+        #Example of if you want to modify node resources
+        #machineSpec:
+        #  controlPlane:
+        #    numCores: 2
+        #    numSockets: 1
+        #    memoryMiB: 4096
+        #  workerNode:
+        #    numCores: 6
+        #    numSockets: 1
+        #    memoryMiB: 6144
+        #    disks:
+        #      bootVolume:
+        #        disk: scsi0
+        #        sizeGb: 80
     - name: controlPlaneEndpoint
       value:
         host: 192.168.2.201

--- a/readme.md
+++ b/readme.md
@@ -141,9 +141,24 @@ stringData:
   PROXMOX_ISO_POOL: "local" #this should be fine for the most users
   PROXMOX_BRIDGE: "vmbr0" #this should be fine for the most users
   PROXMOX_STORAGE_POOL: "local" #this should be fine for the most users
-  PACKER_FLAGS: "--var memory=4096 --var 'kubernetes_rpm_version=1.33.1' --var 'kubernetes_semver=v1.33.1' --var 'kubernetes_series=v1.33' --var 'kubernetes_deb_version=1.33.1-1.1'"
+  PACKER_FLAGS: >-
+   --var memory=4096 
+   --var kubernetes_rpm_version=1.33.1
+   --var kubernetes_semver=v1.33.1 
+   --var kubernetes_series=v1.33 
+   --var kubernetes_deb_version=1.33.1-1.1
+   --var iso_url=https://releases.ubuntu.com/noble/ubuntu-24.04.3-live-server-amd64.iso
+   --var iso_checksum=c3514bf0056180d09376462a7a1b4f213c1d6e8ea67fae5c25099c6fd3d8274b
 ```
 Configure needed values and save the File.
+
+If the builder complains about the storage for lvm-thin add this to the packer flags.
+```yaml
+--var disk_format=raw
+```
+
+
+
 
 Now we need also a Job which creates the Image. A Job is a Kubernetes Pod which is only executed once with a finite life - until the Job successfully complete. It uses Image-Builder Docker-Image with the required configuration to build Kubernetes Proxmox VM-Templates. 
 ```yaml

--- a/readme.md
+++ b/readme.md
@@ -147,17 +147,19 @@ stringData:
    --var kubernetes_semver=v1.33.1 
    --var kubernetes_series=v1.33 
    --var kubernetes_deb_version=1.33.1-1.1
-   --var iso_url=https://releases.ubuntu.com/noble/ubuntu-24.04.3-live-server-amd64.iso
-   --var iso_checksum=c3514bf0056180d09376462a7a1b4f213c1d6e8ea67fae5c25099c6fd3d8274b
 ```
 Configure needed values and save the File.
+
+Example on how to use ubuntu server
+```yaml
+  --var iso_url=https://releases.ubuntu.com/noble/ubuntu-24.04.3-live-server-amd64.iso
+  --var iso_checksum=c3514bf0056180d09376462a7a1b4f213c1d6e8ea67fae5c25099c6fd3d8274b
+```
 
 If the builder complains about the storage for lvm-thin add this to the packer flags.
 ```yaml
 --var disk_format=raw
 ```
-
-
 
 
 Now we need also a Job which creates the Image. A Job is a Kubernetes Pod which is only executed once with a finite life - until the Job successfully complete. It uses Image-Builder Docker-Image with the required configuration to build Kubernetes Proxmox VM-Templates. 
@@ -486,6 +488,8 @@ spec:
     variables:
     - name: cloneSpec
       value:
+        sshAuthorizedKeys:
+          - "ssh-ed25519 replace-with-your-ssh-key-and-ssh-to-node-ip-as root"
         vmTemplate:
           sourceNode: node01
           templateID: 114


### PR DESCRIPTION
Fixes and adds support for changing the Proxmox values for:

- Control plane 
    - Boot disk size
    - Core count
    - Memory config
    - Socket count

- Worker node
   - Boot disk size
   - Socket count
   
Also updated readme with more details on template creation and cluster config options.
---
Note: I did not change the references to my fork/git commit hashes as this PR should be merged first then those should be updated to use the main repo.