### PR TITLE
added LoadBalancer feature 

### DIFF
--- a/manifests/clusterclass-cilium-with-shared-ippool/base/kustomization.yaml
+++ b/manifests/clusterclass-cilium-with-shared-ippool/base/kustomization.yaml
@@ -10,6 +10,7 @@ resources:
   - templates/proxmox-cluster-template.yaml
   - templates/proxmox-machine-template-cp.yaml
   - templates/proxmox-machine-template-worker.yaml
+  - templates/svc-lb
 #  - templates/ip-pool.yaml - configure this in your overlay
 
 patches:

--- a/manifests/clusterclass-cilium-with-shared-ippool/base/templates/svc-lb/clusterresourceset-kube-vip.yaml
+++ b/manifests/clusterclass-cilium-with-shared-ippool/base/templates/svc-lb/clusterresourceset-kube-vip.yaml
@@ -1,0 +1,12 @@
+apiVersion: addons.cluster.x-k8s.io/v1beta1
+kind: ClusterResourceSet
+metadata:
+  name: svc-lb-kube-vip
+spec:
+  strategy: Reconcile
+  clusterSelector:
+    matchLabels:
+      caprox.eu/service-lb: "true"
+  resources:
+    - name: svc-lb-kube-vip
+      kind: ConfigMap

--- a/manifests/clusterclass-cilium-with-shared-ippool/base/templates/svc-lb/kustomization.yaml
+++ b/manifests/clusterclass-cilium-with-shared-ippool/base/templates/svc-lb/kustomization.yaml
@@ -1,0 +1,13 @@
+# add here stuff for generating configmap out of the svc-lb sources
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+    - clusterresourceset-kube-vip.yaml
+configMapGenerator:
+  - name: svc-lb-kube-vip
+    files:
+      - sources/kube-vip-cloud-controller.yaml
+      - sources/kube-vip-svc-lb.yaml
+      - sources/cm.yaml
+    options:
+      disableNameSuffixHash: true

--- a/manifests/clusterclass-cilium-with-shared-ippool/base/templates/svc-lb/sources/cm.yaml
+++ b/manifests/clusterclass-cilium-with-shared-ippool/base/templates/svc-lb/sources/cm.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+data:
+  cidr-global: 0.0.0.0/32
+kind: ConfigMap
+metadata:
+  name: kubevip
+  namespace: kube-system

--- a/manifests/clusterclass-cilium-with-shared-ippool/base/templates/svc-lb/sources/kube-vip-cloud-controller.yaml
+++ b/manifests/clusterclass-cilium-with-shared-ippool/base/templates/svc-lb/sources/kube-vip-cloud-controller.yaml
@@ -1,0 +1,89 @@
+# https://github.com/kube-vip/kube-vip-cloud-provider/blob/v0.0.12/manifest/kube-vip-cloud-controller.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kube-vip-cloud-controller
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    rbac.authorization.kubernetes.io/autoupdate: "true"
+  name: system:kube-vip-cloud-controller-role
+rules:
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "create", "update", "list", "put"]
+  - apiGroups: [""]
+    resources: ["configmaps", "endpoints","events","services/status", "leases"]
+    verbs: ["*"]
+  - apiGroups: [""]
+    resources: ["nodes", "services"]
+    verbs: ["list","get","watch","update"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: system:kube-vip-cloud-controller-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:kube-vip-cloud-controller-role
+subjects:
+- kind: ServiceAccount
+  name: kube-vip-cloud-controller
+  namespace: kube-system
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kube-vip-cloud-provider
+  namespace: kube-system
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app: kube-vip
+      component: kube-vip-cloud-provider
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: kube-vip
+        component: kube-vip-cloud-provider
+    spec:
+      containers:
+      - command:
+        - /kube-vip-cloud-provider
+        - --leader-elect-resource-name=kube-vip-cloud-controller
+        image: ghcr.io/kube-vip/kube-vip-cloud-provider:v0.0.12
+        name: kube-vip-cloud-provider
+        imagePullPolicy: Always
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      terminationGracePeriodSeconds: 30
+      serviceAccountName: kube-vip-cloud-controller
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        effect: NoSchedule
+      - key: node-role.kubernetes.io/control-plane
+        effect: NoSchedule
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 10
+            preference:
+              matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+          - weight: 10
+            preference:
+              matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists

--- a/manifests/clusterclass-cilium-with-shared-ippool/base/templates/svc-lb/sources/kube-vip-svc-lb.yaml
+++ b/manifests/clusterclass-cilium-with-shared-ippool/base/templates/svc-lb/sources/kube-vip-svc-lb.yaml
@@ -1,0 +1,95 @@
+
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kube-vip
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    rbac.authorization.kubernetes.io/autoupdate: "true"
+  name: system:kube-vip-role
+rules:
+  - apiGroups: [""]
+    resources: ["services/status"]
+    verbs: ["update"]
+  - apiGroups: [""]
+    resources: ["services", "endpoints"]
+    verbs: ["list","get","watch", "update"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["list","get","watch", "update", "patch"]
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["list", "get", "watch", "update", "create"]
+  - apiGroups: ["discovery.k8s.io"]
+    resources: ["endpointslices"]
+    verbs: ["list","get","watch", "update"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["list"]
+
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: system:kube-vip-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:kube-vip-role
+subjects:
+- kind: ServiceAccount
+  name: kube-vip
+  namespace: kube-system
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/name: kube-vip-ds
+    app.kubernetes.io/version: v1.0.0
+  name: kube-vip-ds
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: kube-vip-ds
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app.kubernetes.io/name: kube-vip-ds
+        app.kubernetes.io/version: v1.0.0
+    spec:
+      containers:
+      - args:
+        - manager
+        env:
+        - name: vip_arp
+          value: "true"
+        - name: vip_nodename
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: svc_enable
+          value: "true"
+        image: ghcr.io/kube-vip/kube-vip:v1.0.0
+        imagePullPolicy: IfNotPresent
+        name: kube-vip
+        resources: {}
+        securityContext:
+          capabilities:
+            add:
+            - NET_ADMIN
+            - NET_RAW
+            drop:
+            - ALL
+      hostNetwork: true
+      serviceAccountName: kube-vip
+  updateStrategy: {}


### PR DESCRIPTION
This introduces service Loadbalancers for the workload-clusters. The only requirement is a DHCP-Server within the network.
Just create a service from type loadbalancer and you will get a IPv4 from your networks DHCP for you Loadbalancers. 
```
k create svc loadbalancer test --tcp 80
service/test created
...
k get svc
NAME         TYPE           CLUSTER-IP    EXTERNAL-IP    PORT(S)        AGE
kubernetes   ClusterIP      10.96.0.1     <none>         443/TCP        16m
test         LoadBalancer   10.96.4.224   192.168.2.25   80:31976/TCP   6s
```
